### PR TITLE
Auto-calc sale cost from inventory

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,9 +10,7 @@ app.config['SECRET_KEY'] = 'dev'
 
 db.init_app(app)
 
-
-@app.before_first_request
-def create_tables():
+with app.app_context():
     db.create_all()
 
 
@@ -49,9 +47,8 @@ def add_variation():
     if request.method == 'POST':
         species_id = request.form.get('species_id')
         name = request.form.get('name')
-        price = request.form.get('price')
-        if species_id and name and price:
-            variation = Variation(species_id=species_id, name=name, price_per_kg=float(price))
+        if species_id and name:
+            variation = Variation(species_id=species_id, name=name)
             db.session.add(variation)
             db.session.commit()
             flash('Variation added')
@@ -84,26 +81,52 @@ def add_sale():
         purchase_variation_id = request.form.get('purchase_variation_id')
         sold_variation_id = request.form.get('sold_variation_id')
         weight = request.form.get('weight')
-        cost = request.form.get('cost')
         price = request.form.get('price')
-        if purchase_variation_id and sold_variation_id and weight and cost and price:
-            purchase_variation = Variation.query.get(purchase_variation_id)
-            sale = Sale(
-                species_id=purchase_variation.species_id,
-                purchase_variation_id=purchase_variation_id,
-                sold_variation_id=sold_variation_id,
-                weight_kg=float(weight),
-                sale_price_per_kg=float(price),
-                cost_per_kg=float(cost),
-            )
-            db.session.add(sale)
-            db.session.commit()
-            generate_receipt(sale)
-            sync_sale_to_google_sheets(sale)
-            flash('Sale recorded')
+        if purchase_variation_id and sold_variation_id and weight and price:
+            cost_per_kg = consume_inventory_cost(int(purchase_variation_id), float(weight))
+            if cost_per_kg is None:
+                flash('Insufficient inventory')
+            else:
+                purchase_variation = Variation.query.get(purchase_variation_id)
+                sale = Sale(
+                    species_id=purchase_variation.species_id,
+                    purchase_variation_id=purchase_variation_id,
+                    sold_variation_id=sold_variation_id,
+                    weight_kg=float(weight),
+                    sale_price_per_kg=float(price),
+                    cost_per_kg=cost_per_kg,
+                )
+                db.session.add(sale)
+                db.session.commit()
+                generate_receipt(sale)
+                sync_sale_to_google_sheets(sale)
+                flash('Sale recorded')
         return redirect(url_for('add_sale'))
     sales = Sale.query.order_by(Sale.timestamp.desc()).all()
     return render_template('sale.html', variations=variations, sales=sales)
+
+
+def consume_inventory_cost(variation_id: int, weight_needed: float):
+    inventory_items = (
+        Inventory.query.filter_by(variation_id=variation_id)
+        .order_by(Inventory.id)
+        .all()
+    )
+    total_available = sum(item.weight_kg for item in inventory_items)
+    if total_available < weight_needed:
+        return None
+    remaining = weight_needed
+    total_cost = 0.0
+    for item in inventory_items:
+        if remaining <= 0:
+            break
+        used = min(item.weight_kg, remaining)
+        total_cost += used * item.cost_per_kg
+        item.weight_kg -= used
+        remaining -= used
+        if item.weight_kg == 0:
+            db.session.delete(item)
+    return total_cost / weight_needed
 
 
 def generate_receipt(sale: Sale):

--- a/models.py
+++ b/models.py
@@ -14,7 +14,6 @@ class Variation(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     species_id = db.Column(db.Integer, db.ForeignKey('species.id'), nullable=False)
     name = db.Column(db.String(50), nullable=False)
-    price_per_kg = db.Column(db.Float, nullable=False)
 
     species = db.relationship('Species', backref=db.backref('variations', lazy=True))
 

--- a/templates/sale.html
+++ b/templates/sale.html
@@ -18,13 +18,10 @@
       {% endfor %}
     </select>
   </div>
-  <div class="col-md-2">
+  <div class="col-md-3">
     <input type="number" step="0.01" class="form-control" name="weight" placeholder="Weight kg" required>
   </div>
-  <div class="col-md-2">
-    <input type="number" step="0.01" class="form-control" name="cost" placeholder="Cost/kg" required>
-  </div>
-  <div class="col-md-2">
+  <div class="col-md-3">
     <input type="number" step="0.01" class="form-control" name="price" placeholder="Price/kg" required>
   </div>
   <div class="col-md-12">

--- a/templates/variation.html
+++ b/templates/variation.html
@@ -13,9 +13,6 @@
   <div class="col-md-3">
     <input type="text" class="form-control" name="name" placeholder="Variation" required>
   </div>
-  <div class="col-md-3">
-    <input type="number" step="0.01" class="form-control" name="price" placeholder="Price/kg" required>
-  </div>
   <div class="col-md-2">
     <button type="submit" class="btn btn-primary">Add</button>
   </div>
@@ -25,7 +22,6 @@
     <tr>
       <th>Species</th>
       <th>Variation</th>
-      <th>Price/kg</th>
     </tr>
   </thead>
   <tbody>
@@ -33,7 +29,6 @@
     <tr>
       <td>{{ v.species.name }}</td>
       <td>{{ v.name }}</td>
-      <td>{{ '%.2f'|format(v.price_per_kg) }}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- Initialize database tables at startup using an application context
- Compute sale cost from existing inventory to avoid duplicate cost entry
- Remove variation pricing to rely solely on inventory costs

## Testing
- `python -m py_compile app.py database.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d48f9564832bb13dbd7950cb22f2