### PR TITLE
Auto-calc sale cost from inventory

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,5 @@
 import os
+from datetime import datetime, timedelta
 from flask import Flask, render_template, request, redirect, url_for, flash
 from database import db
 from models import Species, Variation, Inventory, Sale
@@ -10,15 +11,22 @@ app.config['SECRET_KEY'] = 'dev'
 
 db.init_app(app)
 
-
-@app.before_first_request
-def create_tables():
+with app.app_context():
     db.create_all()
 
 
 @app.route('/')
 def dashboard():
-    sales = Sale.query.all()
+    start = request.args.get('start')
+    end = request.args.get('end')
+    sales_query = Sale.query
+    if start:
+        start_dt = datetime.fromisoformat(start)
+        sales_query = sales_query.filter(Sale.timestamp >= start_dt)
+    if end:
+        end_dt = datetime.fromisoformat(end) + timedelta(days=1)
+        sales_query = sales_query.filter(Sale.timestamp < end_dt)
+    sales = sales_query.order_by(Sale.timestamp.desc()).all()
     total_profit = sum(s.profit for s in sales)
     mapping_totals = {}
     for s in sales:
@@ -27,7 +35,18 @@ def dashboard():
         data['weight'] += s.weight_kg
         data['revenue'] += s.revenue
         data['profit'] += s.profit
-    return render_template('dashboard.html', total_profit=total_profit, mapping_totals=mapping_totals)
+    stock_totals = {}
+    for inv in Inventory.query.all():
+        key = (inv.variation.species.name, inv.variation.name)
+        stock_totals[key] = stock_totals.get(key, 0) + inv.weight_kg
+    return render_template(
+        'dashboard.html',
+        total_profit=total_profit,
+        mapping_totals=mapping_totals,
+        stock_totals=stock_totals,
+        start=start,
+        end=end,
+    )
 
 
 @app.route('/species', methods=['GET', 'POST'])
@@ -49,9 +68,8 @@ def add_variation():
     if request.method == 'POST':
         species_id = request.form.get('species_id')
         name = request.form.get('name')
-        price = request.form.get('price')
-        if species_id and name and price:
-            variation = Variation(species_id=species_id, name=name, price_per_kg=float(price))
+        if species_id and name:
+            variation = Variation(species_id=species_id, name=name)
             db.session.add(variation)
             db.session.commit()
             flash('Variation added')
@@ -67,13 +85,20 @@ def add_inventory():
         variation_id = request.form.get('variation_id')
         weight = request.form.get('weight')
         cost = request.form.get('cost')
+        date = request.form.get('date')
         if variation_id and weight and cost:
-            inv = Inventory(variation_id=variation_id, weight_kg=float(weight), cost_per_kg=float(cost))
+            ts = datetime.fromisoformat(date) if date else datetime.utcnow()
+            inv = Inventory(
+                variation_id=variation_id,
+                weight_kg=float(weight),
+                cost_per_kg=float(cost),
+                timestamp=ts,
+            )
             db.session.add(inv)
             db.session.commit()
             flash('Inventory recorded')
         return redirect(url_for('add_inventory'))
-    inventory = Inventory.query.all()
+    inventory = Inventory.query.order_by(Inventory.timestamp.desc()).all()
     return render_template('inventory.html', variations=variations, inventory=inventory)
 
 
@@ -84,26 +109,55 @@ def add_sale():
         purchase_variation_id = request.form.get('purchase_variation_id')
         sold_variation_id = request.form.get('sold_variation_id')
         weight = request.form.get('weight')
-        cost = request.form.get('cost')
         price = request.form.get('price')
-        if purchase_variation_id and sold_variation_id and weight and cost and price:
-            purchase_variation = Variation.query.get(purchase_variation_id)
-            sale = Sale(
-                species_id=purchase_variation.species_id,
-                purchase_variation_id=purchase_variation_id,
-                sold_variation_id=sold_variation_id,
-                weight_kg=float(weight),
-                sale_price_per_kg=float(price),
-                cost_per_kg=float(cost),
-            )
-            db.session.add(sale)
-            db.session.commit()
-            generate_receipt(sale)
-            sync_sale_to_google_sheets(sale)
-            flash('Sale recorded')
+        date = request.form.get('date')
+        if purchase_variation_id and sold_variation_id and weight and price:
+            cost_per_kg = consume_inventory_cost(int(purchase_variation_id), float(weight))
+            if cost_per_kg is None:
+                flash('Insufficient inventory')
+            else:
+                ts = datetime.fromisoformat(date) if date else datetime.utcnow()
+                purchase_variation = Variation.query.get(purchase_variation_id)
+                sale = Sale(
+                    species_id=purchase_variation.species_id,
+                    purchase_variation_id=purchase_variation_id,
+                    sold_variation_id=sold_variation_id,
+                    weight_kg=float(weight),
+                    sale_price_per_kg=float(price),
+                    cost_per_kg=cost_per_kg,
+                    timestamp=ts,
+                )
+                db.session.add(sale)
+                db.session.commit()
+                generate_receipt(sale)
+                sync_sale_to_google_sheets(sale)
+                flash('Sale recorded')
         return redirect(url_for('add_sale'))
     sales = Sale.query.order_by(Sale.timestamp.desc()).all()
     return render_template('sale.html', variations=variations, sales=sales)
+
+
+def consume_inventory_cost(variation_id: int, weight_needed: float):
+    inventory_items = (
+        Inventory.query.filter_by(variation_id=variation_id)
+        .order_by(Inventory.id)
+        .all()
+    )
+    total_available = sum(item.weight_kg for item in inventory_items)
+    if total_available < weight_needed:
+        return None
+    remaining = weight_needed
+    total_cost = 0.0
+    for item in inventory_items:
+        if remaining <= 0:
+            break
+        used = min(item.weight_kg, remaining)
+        total_cost += used * item.cost_per_kg
+        item.weight_kg -= used
+        remaining -= used
+        if item.weight_kg == 0:
+            db.session.delete(item)
+    return total_cost / weight_needed
 
 
 def generate_receipt(sale: Sale):

--- a/models.py
+++ b/models.py
@@ -14,7 +14,6 @@ class Variation(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     species_id = db.Column(db.Integer, db.ForeignKey('species.id'), nullable=False)
     name = db.Column(db.String(50), nullable=False)
-    price_per_kg = db.Column(db.Float, nullable=False)
 
     species = db.relationship('Species', backref=db.backref('variations', lazy=True))
 
@@ -27,6 +26,7 @@ class Inventory(db.Model):
     variation_id = db.Column(db.Integer, db.ForeignKey('variation.id'), nullable=False)
     weight_kg = db.Column(db.Float, nullable=False)
     cost_per_kg = db.Column(db.Float, nullable=False)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
 
     variation = db.relationship('Variation')
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -1,8 +1,19 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Dashboard</h2>
+<form method="get" class="row g-3 mb-3">
+  <div class="col-md-3">
+    <input type="date" class="form-control" name="start" value="{{ start }}" placeholder="Start date">
+  </div>
+  <div class="col-md-3">
+    <input type="date" class="form-control" name="end" value="{{ end }}" placeholder="End date">
+  </div>
+  <div class="col-md-2">
+    <button type="submit" class="btn btn-primary">Filter</button>
+  </div>
+</form>
 <p>Total Profit: {{ '%.2f'|format(total_profit) }}</p>
-<table class="table table-striped">
+<table class="table table-striped mb-4">
   <thead>
     <tr>
       <th>Species</th>
@@ -22,6 +33,26 @@
       <td>{{ '%.2f'|format(data.weight) }}</td>
       <td>{{ '%.2f'|format(data.revenue) }}</td>
       <td>{{ '%.2f'|format(data.profit) }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h3>Stock Remaining</h3>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th>Species</th>
+      <th>Variation</th>
+      <th>Kg</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for key, weight in stock_totals.items() %}
+    <tr>
+      <td>{{ key[0] }}</td>
+      <td>{{ key[1] }}</td>
+      <td>{{ '%.2f'|format(weight) }}</td>
     </tr>
     {% endfor %}
   </tbody>

--- a/templates/inventory.html
+++ b/templates/inventory.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Inventory</h2>
 <form method="post" class="row g-3 mb-3">
-  <div class="col-md-4">
+  <div class="col-md-3">
     <select name="variation_id" class="form-select" required>
       <option value="">Variation</option>
       {% for v in variations %}
@@ -10,11 +10,14 @@
       {% endfor %}
     </select>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-2">
     <input type="number" step="0.01" class="form-control" name="weight" placeholder="Weight kg" required>
   </div>
-  <div class="col-md-3">
+  <div class="col-md-2">
     <input type="number" step="0.01" class="form-control" name="cost" placeholder="Cost/kg" required>
+  </div>
+  <div class="col-md-3">
+    <input type="date" class="form-control" name="date" required>
   </div>
   <div class="col-md-2">
     <button type="submit" class="btn btn-primary">Add</button>
@@ -23,6 +26,7 @@
 <table class="table table-striped">
   <thead>
     <tr>
+      <th>Date</th>
       <th>Variation</th>
       <th>Weight kg</th>
       <th>Cost/kg</th>
@@ -31,6 +35,7 @@
   <tbody>
     {% for i in inventory %}
     <tr>
+      <td>{{ i.timestamp.strftime('%Y-%m-%d') }}</td>
       <td>{{ i.variation.species.name }} - {{ i.variation.name }}</td>
       <td>{{ '%.2f'|format(i.weight_kg) }}</td>
       <td>{{ '%.2f'|format(i.cost_per_kg) }}</td>

--- a/templates/sale.html
+++ b/templates/sale.html
@@ -22,18 +22,19 @@
     <input type="number" step="0.01" class="form-control" name="weight" placeholder="Weight kg" required>
   </div>
   <div class="col-md-2">
-    <input type="number" step="0.01" class="form-control" name="cost" placeholder="Cost/kg" required>
-  </div>
-  <div class="col-md-2">
     <input type="number" step="0.01" class="form-control" name="price" placeholder="Price/kg" required>
   </div>
-  <div class="col-md-12">
+  <div class="col-md-2">
+    <input type="date" class="form-control" name="date" required>
+  </div>
+  <div class="col-md-2">
     <button type="submit" class="btn btn-primary">Record Sale</button>
   </div>
 </form>
 <table class="table table-striped">
   <thead>
     <tr>
+      <th>Date</th>
       <th>Purchased As</th>
       <th>Sold As</th>
       <th>Weight kg</th>
@@ -45,6 +46,7 @@
   <tbody>
     {% for s in sales %}
     <tr>
+      <td>{{ s.timestamp.strftime('%Y-%m-%d') }}</td>
       <td>{{ s.purchase_variation.name }}</td>
       <td>{{ s.sold_variation.name }}</td>
       <td>{{ '%.2f'|format(s.weight_kg) }}</td>

--- a/templates/variation.html
+++ b/templates/variation.html
@@ -13,9 +13,6 @@
   <div class="col-md-3">
     <input type="text" class="form-control" name="name" placeholder="Variation" required>
   </div>
-  <div class="col-md-3">
-    <input type="number" step="0.01" class="form-control" name="price" placeholder="Price/kg" required>
-  </div>
   <div class="col-md-2">
     <button type="submit" class="btn btn-primary">Add</button>
   </div>
@@ -25,7 +22,6 @@
     <tr>
       <th>Species</th>
       <th>Variation</th>
-      <th>Price/kg</th>
     </tr>
   </thead>
   <tbody>
@@ -33,7 +29,6 @@
     <tr>
       <td>{{ v.species.name }}</td>
       <td>{{ v.name }}</td>
-      <td>{{ '%.2f'|format(v.price_per_kg) }}</td>
     </tr>
     {% endfor %}
   </tbody>


### PR DESCRIPTION
## Summary
- Initialize database tables at startup using an application context
- Compute sale cost from existing inventory to avoid duplicate cost entry
- Remove variation pricing to rely solely on inventory costs
- Record dates on inventory and sales entries
- Filter dashboard totals by date range and display remaining stock

## Testing
- `python -m py_compile app.py database.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68c6d48f9564832bb13dbd7950cb22f2